### PR TITLE
Set max-width of the email to 650px and font to 16px

### DIFF
--- a/src/MarkdownEmail.tsx
+++ b/src/MarkdownEmail.tsx
@@ -26,7 +26,8 @@ export function MarkdownEmail({ filename }: { filename: string }) {
               font-family: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
               padding: 24px;
               line-height: 1.5;
-              max-width: 820px;
+              max-width: 650px;
+              font-size: 16px;
               margin: 0 auto;
               color: black;
               background: white;


### PR DESCRIPTION
A follow up to [conversation on Slack](https://graphprotocol.slack.com/archives/C04BASED88P/p1694527494293019?thread_ts=1694525900.883459&cid=C04BASED88P).

Take note that I did not upload the templates to Campaign Monitor yet.